### PR TITLE
Fixes bug introduced by edx-platform commit e723fb6a

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ before_install:
     - "sh -e /etc/init.d/xvfb start"
 install:
     - "pip install -e git://github.com/edx/xblock-sdk.git#egg=xblock-sdk"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/test-requirements.txt"
+    - "make -C $VIRTUAL_ENV/src/xblock-sdk install"
     - "python setup.py develop"
-script: pep8 leaderboards --max-line-length=120 && pylint leaderboards && python run_tests.py --with-coverage --cover-package=leaderboards
+script: pep8 leaderboards --max-line-length=120 && pylint leaderboards && python run_tests.py --with-coverage --cover-package=leaderboards --settings=workbench.settings
 notifications:
   email: false

--- a/leaderboards/dummy_cc.py
+++ b/leaderboards/dummy_cc.py
@@ -1,6 +1,7 @@
 """
 Dummy comment client module, used for testing.
 """
+from mock import Mock
 
 
 def make_thread_dict(number, points):
@@ -33,6 +34,9 @@ class Thread(object):
         # Could be 0.
         end = end and end + 1
         commentable_id = search_dict['commentable_id']
-        if commentable_id not in test_ids:
-            return [[]]
-        return [test_ids[commentable_id][0:end]]
+        threads = Mock()
+        if commentable_id in test_ids:
+            threads.collection = test_ids[commentable_id][0:end]
+        else:
+            threads.collection = []
+        return threads

--- a/leaderboards/forum_leaderboard.py
+++ b/leaderboards/forum_leaderboard.py
@@ -59,7 +59,7 @@ class ForumLeaderboardXBlock(LeaderboardXBlock):
         threads = cc.Thread.search({
             'course_id': unicode(course), 'commentable_id': self.discussion_id,
             'sort_key': 'votes', 'per_page': self.count - 1
-        })[0]
+        }).collection
 
         scored_threads = []
         for thread in threads:

--- a/run_tests.py
+++ b/run_tests.py
@@ -22,6 +22,12 @@ if __name__ == "__main__":
     # Configure a range of ports in case the default port of 8081 is in use
     os.environ.setdefault("DJANGO_LIVE_TEST_SERVER_ADDRESS", "localhost:8081-8099")
 
+    try:
+        os.mkdir('var')
+    except OSError:
+        # May already exist.
+        pass
+
     from django.core.management import execute_from_command_line
     args = sys.argv[1:]
     paths = [arg for arg in args if arg[0] != '-']


### PR DESCRIPTION
Description goes here. e.g. This PR contains the LibraryContent XBlock, which allows to display library content in a course.

**JIRA tickets**: Discovered while testing OC-1504

**Dependencies**: edx-platform master (commit [e723fb6a](https://github.com/edx/edx-platform/commit/e723fb6aecd817ca5b99882f0ae911e95a191b58#diff-cb19c9e0f86ff55cfcfd9693cf9dfdfaL116)).

**Screenshots**:

![screen shot 2016-04-24 at 6 24 22 pm](https://cloud.githubusercontent.com/assets/7556571/14766456/e9cc41a4-0a49-11e6-9f1c-223424ae968d.png)

**Sandbox URL**: http://pr12195.sandbox.opencraft.com

**Testing instructions**:

To verify error in master branch:
1. Set up devstack with settings:

``` yaml
OPENEDX_RELEASE="master"
FEATURES:
    ALLOW_ALL_ADVANCED_COMPONENTS: true
```
1. Install leaderboard@master by adding this line to `/edx/app/edxapp/edx-platform/requirements/edx/github.txt`:
   
   ```
   -e git+https://github.com/open-craft/xblock-leaderboard@master#egg=xblock-leaderboard==master
   ```
2. Launch Studio, LMS, and Forum.
3. In Studio, create a course with a leaderboard xblock, linked to an existing discussion thread (e.g. `general`).
4.  Preview course in LMS, and post to the target discussion board.  Up-vote that post.
5.  View leaderboard in course preview.  Will see the following error on screen:
   ![screen shot 2016-04-24 at 6 46 21 pm](https://cloud.githubusercontent.com/assets/7556571/14766522/e37a0f72-0a4c-11e6-8cee-cf0c2183ecd4.png)

And in the logs:

```
ERROR 7706 [leaderboards.leaderboard] leaderboard.py:94 - Unable to get_scores() for leaderboard.
Traceback (most recent call last):
   File "/edx/app/edxapp/venvs/edxapp/src/xblock-leaderboard/leaderboards/leaderboard.py", line 92, in student_view
    data = self.get_scores()
   File "/edx/app/edxapp/venvs/edxapp/src/xblock-leaderboard/leaderboards/forum_leaderboard.py", line 62, in get_scores
})[0]
 TypeError: 'CommentClientPaginatedResult' object does not support indexing
```

To verify the fix:
1. Install leaderboard@master by changing the above line in `/edx/app/edxapp/edx-platform/requirements/edx/github.txt` to:
   
   ```
   -e git+https://github.com/open-craft/xblock-leaderboard@jill/fix-thread-search#egg=xblock-leaderboard==fix-thread-search
   ```
2. Restart Studio and LMS
3. Refresh the leaderboard unit in course preview.  Should see a link to your up-voted post, and no error in the logs.

**Reviewers**
- [x] @smarnach 
